### PR TITLE
Resolve issue with React Native WebView postMessage

### DIFF
--- a/src/editor/main.ts
+++ b/src/editor/main.ts
@@ -82,7 +82,8 @@ export type NativeMessage =
   | { kind: "editor"; payload: "focus" | "blur" }
   | { kind: "initialContent"; payload: string };
 
-window.addEventListener("message", (message: { data: string }) => {
+function handleMessageEvent(event: MessageEvent | Event) {
+  const message: { data: string } = event as { data: string };
   const nativeMessage: NativeMessage = JSON.parse(message.data);
   if (nativeMessage.kind === "action") {
     const fn = editorActions[nativeMessage.payload];
@@ -99,4 +100,8 @@ window.addEventListener("message", (message: { data: string }) => {
       editor.commands.blur();
     }
   }
-});
+}
+
+window.addEventListener("message", handleMessageEvent);
+
+document.addEventListener("message", handleMessageEvent);


### PR DESCRIPTION
## Description

This PR addresses the problem where communication via postMessage between the web app and React Native app was not functioning correctly on Android. This is due to the implementation of how the event listeners on Android work, more about the bug can be found on this StackOverflow thread [here](https://stackoverflow.com/questions/41160221/react-native-webview-postmessage-does-not-work). To fix it I have created an additional event listener allowing for both platforms to be targeted and moved the event handler to a separate function.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Further comments

Closes #1 

https://github.com/nstfkc/tiptap-react-native-example/assets/54673427/e5157d1d-360f-4c8d-9b6e-08badc7d35cd

https://github.com/nstfkc/tiptap-react-native-example/assets/54673427/bc506ba9-a100-4901-a7a0-f6f57eed3ceb


